### PR TITLE
Add Bootstrap Gems and Hooks in app/assets (JS/CSS) files.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'jbuilder', '~> 2.5'
 # gem 'redis', '~> 3.0'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
+gem 'bootstrap-sass', '~> 3.3.6'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (7.1.1)
+    autoprefixer-rails (6.6.1)
+      execjs
     bcrypt (3.1.11)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -46,6 +48,9 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    bootstrap-sass (3.3.7)
+      autoprefixer-rails (>= 5.2.1)
+      sass (>= 3.3.4)
     builder (3.2.2)
     byebug (9.0.5)
     coderay (1.1.1)
@@ -218,6 +223,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   binding_of_caller
+  bootstrap-sass (~> 3.3.6)
   byebug
   coffee-rails (~> 4.2)
   devise
@@ -242,4 +248,4 @@ DEPENDENCIES
   yelp
 
 BUNDLED WITH
-   1.12.5
+   1.13.7

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,6 +17,6 @@
 //= require angular/angular
 //= require angular-simple-logger/dist/angular-simple-logger
 //= require angular-google-maps/dist/angular-google-maps
-//= require bootstrap.min
+//= require bootstrap-sprockets
 //= require app
 //= require_tree .

--- a/app/assets/stylesheets/_external.css.scss
+++ b/app/assets/stylesheets/_external.css.scss
@@ -1,0 +1,3 @@
+// "bootstrap-sprockets" must be imported before "bootstrap" and "bootstrap/variables"
+@import "bootstrap-sprockets";
+@import "bootstrap";

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,7 +10,6 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require bootstrap.min
  *= require_tree .
  *= require_self
  */


### PR DESCRIPTION
The current 'Amazi' App uses minimized bootstrap components, which requires re-configuration if you want to use bootstrap components that aren't included. 

I think, to make things easier, we can just use the full-fledged Bootstrap for now and minimize later. So I've replaced the current Bootstrap-min with the gem we have used from class.

Though I kept the old 'bootstrap-min' files in case we want to go back to them. 